### PR TITLE
fix startup settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,15 @@ MAINTAINER Xavier Bruhiere
 ADD ./confd.toml /etc/confd/conf.d/sample.toml
 ADD ./conf.js.tmpl /etc/confd/templates/sample.conf.tmpl
 
+#install supervisord
+RUN apt-get update && wget https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py && rm get-pip.py && pip install supervisor
+RUN echo_supervisord_conf > /etc/supervisord.conf \
+    && echo "[program:app]" >> /etc/supervisord.conf \
+    && echo "command=node /usr/src/app/app.js" >> /etc/supervisord.conf \
+    && supervisord -c /etc/supervisord.conf
+
 # install confd
 ADD ./bootstrap-confd.sh /opt/bootstrap-confd.sh
 # script default values are ok here
 RUN /opt/bootstrap-confd.sh
-

--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 var koa = require('koa');
-var conf = require('./conf');
+var conf = require('/tmp/myconfig.conf');
 var app = koa();
 
 app.use(function *() {

--- a/conf.js.tmpl
+++ b/conf.js.tmpl
@@ -1,4 +1,4 @@
 module.exports = {
   port: {{getv "/sample/api/port"}},
-  msg: {{getv "sample/api/msg"}}
+  msg: {{getv "/sample/api/msg"}}
 };

--- a/confd.toml
+++ b/confd.toml
@@ -1,5 +1,5 @@
 [template]
-src = "conf.js.tmpl"
+src = "sample.conf.tmpl"
 dest = "/tmp/myconfig.conf"
 keys = [
   "/sample/api/port",

--- a/confd.toml
+++ b/confd.toml
@@ -5,3 +5,4 @@ keys = [
   "/sample/api/port",
   "/sample/api/msg",
 ]
+reload_cmd = "node /usr/src/app/app.js"

--- a/confd.toml
+++ b/confd.toml
@@ -5,4 +5,4 @@ keys = [
   "/sample/api/port",
   "/sample/api/msg",
 ]
-reload_cmd = "node /usr/src/app/app.js"
+reload_cmd = "supervisorctl restart all"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "confd -backend redis -node ${REDIS_PORT_6379_TCP_ADDR}"
+    "start": "confd -backend redis -node ${REDIS_PORT_6379_TCP_ADDR}:${REDIS_PORT_6379_TCP_PORT} -interval 1"
   },
   "author": "Xavier Bruhiere",
   "license": "MIT",


### PR DESCRIPTION
# Fix startup settings
## Changes
- Source templates rename as defined in `Dockerfile`

```
src = "sample.conf.tmpl"
```
- Package start script : 
  - bind redis port
  - lower down update interval in 1s

``` bash
confd -backend redis -node ${REDIS_PORT_6379_TCP_ADDR}:${REDIS_PORT_6379_TCP_PORT} -interval 1
```
## Usage

``` bash
docker-compose up -d
```

In redis docker, exec sets:

``` bash
redis-cli set /sample/api/port 3000
redis-cli set /sample/api/msg '"hello\n"'
```

now try to curl from the app:

``` bash
curl 192.168.99.100:3000 # instead it with your docker-machine IP

# or in the container
curl localhost:3000
```
